### PR TITLE
Fixed choice building, causing empty value sets to be saved.

### DIFF
--- a/src/Type/Choice.php
+++ b/src/Type/Choice.php
@@ -51,6 +51,8 @@ class Choice extends AbstractType
     public function getValue(bool $raw = false)
     {
         $value = [];
+
+        $this->buildChoices();
         $selectedChoicesValue = $this->getSelectedChoicesValue();
 
         foreach ($selectedChoicesValue as $choiceValue) {
@@ -258,6 +260,9 @@ class Choice extends AbstractType
      */
     public function buildView(): ViewInterface
     {
+        $this->buildChoices();
+        $this->getSelectedChoicesValue();
+
         $view = parent::buildView();
         $view->mergeVars(['allow_clear' => $this->getOption('allow_clear', false),
                           'expanded'    => $this->getOption('expanded', false),


### PR DESCRIPTION
Fixed a bug that happened when I was doing my Group Transformer behavior, due to Choice not rebuilding the choices before needing to access them, that was causing choices values inside of collections not being shown, and choices on elements not being reflected on bound objects.