### PR TITLE
Fix transformer application regarding nested group data.

### DIFF
--- a/src/Collector.php
+++ b/src/Collector.php
@@ -65,7 +65,7 @@ class Collector
             if(!empty($transformer)) {
                 $subMapped = $transformer->toForm($subMapped);
             }
-            
+
             /** @var \Berlioz\Form\ElementInterface $item */
             foreach ($group as $item) {
                 if (!is_null($item->getName())) {


### PR DESCRIPTION
Before this commit, the transformer was applied before mapping the sub-element in the group, which is problematic when mapping a group that is inside a group. Now the transformer will be applied on the subgroup mapped data once it has been resolved from the parent mapped data.