### PR TITLE
Added template blocks for button and submit widgets

### DIFF
--- a/resources/default.html.twig
+++ b/resources/default.html.twig
@@ -88,6 +88,14 @@
   {{ form_errors(form) }}
 {%- endblock -%}
 
+{%- block button_row -%}
+  {{ form_widget(form) }}
+  {{ form_errors(form) }}
+{%- endblock -%}
+
+{%- block submit_row -%}
+  {{ block('button_row') }}
+{%- endblock -%}
 
 {# Label #}
 
@@ -161,4 +169,14 @@
       </optgroup>
     {% endif %}
   {% endfor %}
+{%- endblock -%}
+
+{%- block submit_widget -%}
+  {{ block('button_widget') }}
+{%- endblock -%}
+
+{%- block button_widget -%}
+  <button {{ block('widget_attributes') }} type="{{ type }}" {% if value is not empty %}value="{{ value }}" {% endif %} >
+    {% if label is not empty %}{{ label }}{% endif %}
+  </button>
 {%- endblock -%}


### PR DESCRIPTION
This PR adds 2 template blocks to better style the Button and Submit types, by rendering them as <button> tags instead of <input> and setting the label as the button tag innter HTML. All other attributes are set as before.