### PR TITLE
Fix use of unset during iteration + Allow Collection to be not mapped

### DIFF
--- a/src/Hydrator/CollectionHydrator.php
+++ b/src/Hydrator/CollectionHydrator.php
@@ -52,6 +52,10 @@ class CollectionHydrator extends AbstractHydrator
      */
     public function hydrate(&$mapped)
     {
+        if (!$this->getElement()->getOption('mapped', true, true)) {
+            return;
+        }
+
         $subMapped = $this->getSubMapped($this->getElement(), $mapped);
         $isArray = is_array($subMapped);
         $isArrayAccess = $subMapped instanceof ArrayAccess;

--- a/src/Hydrator/CollectionHydrator.php
+++ b/src/Hydrator/CollectionHydrator.php
@@ -31,7 +31,7 @@ class CollectionHydrator extends AbstractHydrator
     /**
      * CollectionHydrator constructor.
      *
-     * @param Collection $collection
+     * @param \Berlioz\Form\Collection $collection
      */
     public function __construct(Collection $collection)
     {
@@ -40,7 +40,7 @@ class CollectionHydrator extends AbstractHydrator
 
     /**
      * @inheritdoc
-     * @return Collection
+     * @return \Berlioz\Form\Collection
      */
     public function getElement(): ElementInterface
     {

--- a/src/Hydrator/CollectionHydrator.php
+++ b/src/Hydrator/CollectionHydrator.php
@@ -16,7 +16,6 @@ use ArrayAccess;
 use Berlioz\Form\Collection;
 use Berlioz\Form\Element\ElementInterface;
 use Berlioz\Form\Exception\HydratorException;
-use Berlioz\Form\Group;
 use Exception;
 
 /**
@@ -26,13 +25,13 @@ use Exception;
  */
 class CollectionHydrator extends AbstractHydrator
 {
-    /** @var \Berlioz\Form\Collection Collection */
+    /** @var Collection Collection */
     private $collection;
 
     /**
      * CollectionHydrator constructor.
      *
-     * @param \Berlioz\Form\Collection $collection
+     * @param Collection $collection
      */
     public function __construct(Collection $collection)
     {
@@ -41,7 +40,7 @@ class CollectionHydrator extends AbstractHydrator
 
     /**
      * @inheritdoc
-     * @return \Berlioz\Form\Collection
+     * @return Collection
      */
     public function getElement(): ElementInterface
     {
@@ -64,15 +63,23 @@ class CollectionHydrator extends AbstractHydrator
         // Prototype
         $prototype = $this->collection->getPrototype();
 
-        // Delete old values
+        // Get keys submit by form element
         $submittedKeys = array_keys($this->collection->getValue());
+
+        // List submapped's key who need to be remove
+        $removeKey = [];
         foreach ($subMapped as $key=>$value) {
             if (!in_array($key, $submittedKeys)) {
-                unset($subMapped[$key]);
+                $removeKey[] = $key;
             }
         }
 
-        /** @var \Berlioz\Form\Element\ElementInterface $element */
+        // Delete old submapped values
+        foreach ($removeKey as $key) {
+            unset($subMapped[$key]);
+        }
+
+        /** @var ElementInterface $element */
         foreach ($this->collection as $key => $element) {
             if (!in_array($key, $submittedKeys)) {
                 continue;

--- a/src/Hydrator/GroupHydrator.php
+++ b/src/Hydrator/GroupHydrator.php
@@ -48,14 +48,16 @@ class GroupHydrator extends AbstractHydrator
      */
     public function hydrate(&$mapped)
     {
-        if ($this->group->getOption('mapped', false, true)) {
-            $subMapped = $this->getSubMapped($this->getElement(), $mapped);
+        if (!$this->getElement()->getOption('mapped', false, true)) {
+            return;
+        }
 
-            /** @var \Berlioz\Form\Element\ElementInterface $element */
-            foreach ($this->group as $element) {
-                $hydrator = $this->locateHydrator($element);
-                $hydrator->hydrate($subMapped);
-            }
+        $subMapped = $this->getSubMapped($this->getElement(), $mapped);
+
+        /** @var \Berlioz\Form\Element\ElementInterface $element */
+        foreach ($this->group as $element) {
+            $hydrator = $this->locateHydrator($element);
+            $hydrator->hydrate($subMapped);
         }
     }
 }


### PR DESCRIPTION
Fix use of unset during iteration because perform unset during iteration skip next element when mapped value is a ArrayObject.

Allow Collection to be not mapped. Before this the 'mapped' option was not check by the Hydrator.