### PR TITLE
Fix default value when no data submit

### DIFF
--- a/src/Group.php
+++ b/src/Group.php
@@ -153,11 +153,12 @@ class Group extends AbstractTraversableElement
         /** @var \Berlioz\Form\Element\ElementInterface $element */
         foreach ($this as $element) {
             if (!array_key_exists($element->getName(), $values)) {
-                if ($element instanceof Group) {
+                if ($element instanceof TraversableElementInterface) {
                     $element->submitValue([]);
-                else {
-                    $element->submitValue(null);
+                    continue;
                 }
+
+                $element->submitValue(null);
                 continue;
             }
 

--- a/src/Group.php
+++ b/src/Group.php
@@ -145,7 +145,7 @@ class Group extends AbstractTraversableElement
      * @inheritdoc
      */
     public function submitValue($values)
-    {
+    {       
         if (!is_array($values)) {
             throw new FormException('Invalid type of value, array attempted');
         }
@@ -153,7 +153,11 @@ class Group extends AbstractTraversableElement
         /** @var \Berlioz\Form\Element\ElementInterface $element */
         foreach ($this as $element) {
             if (!array_key_exists($element->getName(), $values)) {
-                $element->submitValue(null);
+                if ($element instanceof Group) {
+                    $element->submitValue([]);
+                else {
+                    $element->submitValue(null);
+                }
                 continue;
             }
 

--- a/src/Group.php
+++ b/src/Group.php
@@ -14,6 +14,7 @@ namespace Berlioz\Form;
 
 use Berlioz\Form\Element\AbstractTraversableElement;
 use Berlioz\Form\Element\ElementInterface;
+use Berlioz\Form\Element\TraversableElementInterface;
 use Berlioz\Form\Exception\FormException;
 use Berlioz\Form\View\ViewInterface;
 use InvalidArgumentException;
@@ -145,7 +146,7 @@ class Group extends AbstractTraversableElement
      * @inheritdoc
      */
     public function submitValue($values)
-    {       
+    {
         if (!is_array($values)) {
             throw new FormException('Invalid type of value, array attempted');
         }


### PR DESCRIPTION
If $element is a Group the default value is an empty array. Submit a null value make Group submision failed.